### PR TITLE
Removed locks that serve no purpose

### DIFF
--- a/src/FileDownloader/ChunkFileDownloader.cs
+++ b/src/FileDownloader/ChunkFileDownloader.cs
@@ -90,8 +90,7 @@ namespace ProjectCeleste.GameFiles.GameScanner.FileDownloader
                 var readRanges = CalculateFileChunkRanges();
 
                 //Parallel download
-                var timerSync = new object();
-                using (new Timer(ReportProgress, timerSync, 100, 100))
+                using (new Timer(ReportProgress, null, 100, 100))
                 {
                     await OrchestrateDownloadWorkersAsync(readRanges, ct);
                     _downloadSpeedStopwatch.Stop();
@@ -100,12 +99,12 @@ namespace ProjectCeleste.GameFiles.GameScanner.FileDownloader
                         throw new Exception($"Download was completed ({BytesDownloaded} bytes), but did not receive expected size of {DownloadSize} bytes");
 
                     State = FileDownloaderState.Finalize;
-                    ReportProgress(timerSync); //Forced
+                    ReportProgress(null); //Forced
 
                     WriteChunksToFile(_completedChunks);
 
                     State = FileDownloaderState.Complete;
-                    ReportProgress(timerSync); //Forced
+                    ReportProgress(null); //Forced
                 }
             }
             catch (Exception e)
@@ -212,17 +211,7 @@ namespace ProjectCeleste.GameFiles.GameScanner.FileDownloader
 
         private void ReportProgress(object state)
         {
-            if (!Monitor.TryEnter(state))
-                return;
-
-            try
-            {
-                OnProgressChanged();
-            }
-            finally
-            {
-                Monitor.Exit(state);
-            }
+            OnProgressChanged();
         }
     }
 }

--- a/src/FileDownloader/SimpleFileDownloader.cs
+++ b/src/FileDownloader/SimpleFileDownloader.cs
@@ -67,8 +67,7 @@ namespace ProjectCeleste.GameFiles.GameScanner.FileDownloader
 
                 _stopwatch.Reset();
                 _stopwatch.Start();
-                var timerSync = new object();
-                using (new Timer(ReportProgress, timerSync, 500, 500))
+                using (new Timer(ReportProgress, null, 500, 500))
                 {
                     try
                     {
@@ -137,17 +136,7 @@ namespace ProjectCeleste.GameFiles.GameScanner.FileDownloader
 
         private void ReportProgress(object state)
         {
-            if (!Monitor.TryEnter(state))
-                return;
-
-            try
-            {
-                OnProgressChanged();
-            }
-            finally
-            {
-                Monitor.Exit(state);
-            }
+            OnProgressChanged();
         }
     }
 }


### PR DESCRIPTION
# Description
Removed thread-safety mechanisms (`Monitor.Enter`) that don't serve any purpose. This was used two places: For progress reporting, and ensuring the game scanner is not started when attempting to start another game-scan. In progress-reporting, this mechanism is only useful if the consumer (i.e. a progress bar) of the information would modify the state of the progress indicator, and in this case it does not do so. If it is important that only one event reports progress at a time, the thread safety should be guaranteed by the consumer of the progress information. Each of these events are triggered every 100th ms, and it is not likely for any progress reporting that this would take more than 100ms. Starting the game scan is not likely that will be triggered in such a frequency it will lead to multiple game scans active at the same time. For UI-applications, this is a non-issue as the events are fired from the same UI-thread.
Additionally, the `Monitor.Lock` is causing issues when using `async`. 

This PR would enable solving https://github.com/ProjectCeleste/Celeste_Launcher/issues/45

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings