### PR TITLE
Reduce download workers to 6

### DIFF
--- a/src/FileDownloader/ChunkFileDownloader.cs
+++ b/src/FileDownloader/ChunkFileDownloader.cs
@@ -13,7 +13,7 @@ namespace ProjectCeleste.GameFiles.GameScanner.FileDownloader
     public class ChunkFileDownloader : IFileDownloader
     {
         internal const int MaxChunkSize = 10 * 1024 * 1024; //10Mb
-        private const int MaxConcurrentDownloads = 12;
+        private const int MaxConcurrentDownloads = 6;
 
         private readonly Stopwatch _downloadSpeedStopwatch;
         private readonly string _downloadTempFolder;


### PR DESCRIPTION
# Description
Users with a very specific download profile (either slow or unstable) could get issues with 12 concurrent download workers. I have reduced this to 6 as it still gives a pretty good performance.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings